### PR TITLE
Issue #2: Allow copy-resources to take in multiple directory arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,10 @@ With no configuration quick-sip will save the css file to `'[your project]/dist/
 Whether the styles (`copy-resources`) task should be skipped (`true`) or run (`false`).
 
 ##### [`copy.src`=`options.src`]
-The source directory to copy from.  The task will copy all files matching:
+The source directory to copy from. This can take either a single directory location or an array of locations. In the case you configure it with an array, it
+will use the single exclusion settings for ALL configured locations.
+
+The task will copy all files matching:
 ```javascript
 [
   options.copy.src + '/**/*.*',

--- a/tasks/copy-resources.js
+++ b/tasks/copy-resources.js
@@ -11,10 +11,8 @@ module.exports = function(gulp, newCopyOptions) {
     gulp.task(options.taskPrefix + 'copy-resources', function() {
       var bytes = 0,
           startTime = +new Date();
-      return gulp.src([
-          options.copy.src + '/**/*.*',
-          '!' + options.copy.src + '/**/*.+(' + options.copy.excludes + ')'
-        ])
+
+      return gulp.src(options.copy.buildFullSrcArray())
         .pipe($.tap(function(file, callback) {
           bytes += fs.statSync(file.path).size;
           return callback;

--- a/tasks/utils/options.js
+++ b/tasks/utils/options.js
@@ -44,7 +44,36 @@ module.exports.updateOptions = function(newOptions) {
       skip: false,
       src: options.src,
       excludes: 'scss',
-      dist: options.dist
+      dist: options.dist,
+
+      /**
+       * Constructs the [source, exclusion] pair used when copying resources.
+       * Takes in an optional source location, defaults to the copy.src setting if not provided.
+       */
+      _buildSrcExclusionPair: function(optionalSrc) {
+        var sourceLoc = optionalSrc || this.src;
+        return [
+            sourceLoc + '/**/*.*',
+            '!' + sourceLoc + '/**/*.+(' + this.excludes + ')'
+        ]
+      },
+
+      /**
+       * Builds a flat map of all the [source, exclusion] pairs.
+       * Each item in the copy.src array will construct a new pair. If copy.src is just a single item, return the single pair.
+       */
+      buildFullSrcArray: function() {
+        var copyOptions = this;
+        if (Array.isArray(this.src)) {
+          return this.src.map(function(entry) {
+            return copyOptions._buildSrcExclusionPair(entry);
+          }).reduce(function(copy, exclude) {
+            return copy.concat(exclude);
+          });
+        } else {
+          return this._buildSrcExclusionPair();
+        }
+      }
     }
   };
 


### PR DESCRIPTION
Previously the options.copy.src could only take in a single
configuration. This means that you must have ALL resources under a
single directory, which can get messy. In my change I allow you to
configure the copy task with an array of source locations.

This is achieved by creating the previous pairing array for each
item in the copy.src array and then flattening the resulting nested
array.

Note:
The configured excludes will be applied to ALL items in the configured
source array.