### PR TITLE
Fix #8: Options will not generate browserify.root with "undefined"

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp-tap": "^0.1.3",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
+    "jasmine": "2.3.2",
     "lodash": "^3.10.0",
     "run-sequence": "^1.1.1",
     "vinyl-buffer": "^1.0.0",
@@ -31,5 +32,8 @@
   },
   "engines": {
     "node": ">=0.8.0"
+  },
+  "scripts": {
+    "test": "jasmine"
   }
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,9 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ]
+}

--- a/spec/tests/optionsSpec.js
+++ b/spec/tests/optionsSpec.js
@@ -1,0 +1,67 @@
+var generateOptions = require('../../tasks/utils/options');
+
+describe('Options', function() {
+  it('should produce a unique object every time its run', function() {
+    var options1 = generateOptions(),
+        options2 = generateOptions();
+
+    options1.foo = 'bar';
+    expect(options2.bar).toBeUndefined();
+  });
+
+  it('when given no arguments should produce default options', function() {
+    var options = generateOptions();
+
+    expect(options.dist).toBe('dist');
+    expect(options.clean.dist).toBe('dist');
+  });
+
+  describe('.update', function() {
+    var testDistValue = 'testValue';
+
+    beforeEach(function() {
+      this.defaultOptions = generateOptions();
+    });
+
+
+    it('should be able to update base defaults', function() {
+      var options = this.defaultOptions.update({dist: testDistValue});
+
+      expect(options.dist).toBe(testDistValue);
+    });
+
+    it('should be able to update bundle options', function() {
+      var options = this.defaultOptions.update({
+            clean: {
+              dist: testDistValue
+            }
+          });
+
+      expect(options.clean.dist).toBe(testDistValue);
+    });
+
+    it('if bundle option is not defined, should default to base option', function() {
+      var options = this.defaultOptions.update({
+        dist: testDistValue
+      });
+
+      expect(options.clean.dist).toBe(testDistValue);
+    });
+
+    it('should use the base default value for bundle options when the bundle option is not specified by the user', function() {
+      var options = this.defaultOptions.update({
+          browserify: {
+            transforms: [
+              {transform: 'aliasify', options: {global: true}},
+              'hbsfy'
+            ]
+          }
+      });
+
+      expect(options.src).toBeDefined();
+      expect(options.src).toBe('app');
+      expect(options.browserify.root).toBe('./app/app');
+
+    });
+  });
+});

--- a/tasks/utils/options.js
+++ b/tasks/utils/options.js
@@ -5,7 +5,7 @@ var _ = require('lodash'),
 // This options object should be generated once for each execution of quick-sip
 // and passed into all task registrations that require this object
 module.exports = function() {
-  var topLevelDefaults = {
+  var baseDefaults = {
         taskPrefix: '',
         src: 'app',
         dist: 'dist',
@@ -16,7 +16,7 @@ module.exports = function() {
       },
       options;
 
-  // Generate defaults from an options parameter
+  // Generate bundle defaults from an options parameter
   function generateBundleDefaults(opts) {
     return {
       clean: {
@@ -47,12 +47,12 @@ module.exports = function() {
     };
   }
 
-  options = _.merge({}, topLevelDefaults, generateBundleDefaults(topLevelDefaults));
+  options = _.merge({}, baseDefaults, generateBundleDefaults(baseDefaults));
 
   // Update options
-  // For certain options, if a key isn't defined at the bundle level, it will default to the value specified at the top level
+  // For certain options, if a key isn't defined at the task level, it will default to the value specified at the top level
   options.update = function(newOptions) {
-    var bundleDefaults = generateBundleDefaults(newOptions);
+    var bundleDefaults = generateBundleDefaults(_.merge({}, baseDefaults, newOptions));
 
     return _.merge(options, bundleDefaults, newOptions);
   };


### PR DESCRIPTION
Adds jasmine tests for options