### PR TITLE
issue-15: update del version, pass options to clean task

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "browserify": "^10.2.6",
     "color-log": "0.0.2",
-    "del": "^1.2.0",
+    "del": "2.0.2",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-concat": "^2.6.0",
     "gulp-cssmin": "^0.1.7",

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -7,7 +7,9 @@ module.exports = function(gulp, options) {
     /* Clean the options.clean.dist directory */
     gulp.task(options.taskPrefix + 'clean', function(callback) {
       log.mark('[CLEAN] deleting ' + options.clean.dist);
-      del(options.clean.dist, callback);
+      del(options.clean.dist, options.clean).then(function() {
+        callback();
+      });
     });
   }
 };


### PR DESCRIPTION
Updated the version of del to 2.0.2, which required a small change to
the way the callback was being executed. For some reason, passing the
callback to the then() method was throwing a gulp formatting error.